### PR TITLE
Add S phase picking as an option

### DIFF
--- a/bin/scdlpicker-repicker.py
+++ b/bin/scdlpicker-repicker.py
@@ -68,7 +68,7 @@ def dotted_nslc(pick):
 
 
 def timestamp(t):
-    return (t.isoformat() + "000000")[:23] + "Z"
+    return t.strftime('%Y-%m-%dT%H:%M:%S.%f')[:23] + 'Z'
 
 
 class App(seiscomp.client.Application):
@@ -323,28 +323,38 @@ class App(seiscomp.client.Application):
             # the threshold, this is now a list of (time, confidence)
             # pairs.
             preds = predictions[pick_id]
-
-            triggering_pick = workspace.picks[pick_id]
+            
+            # The current pickID is the triggering pick ID + the phase type. We are separating it again.
+            triggerID, phaseType = pick_id.rsplit('_', maxsplit=1)
+            
+            triggering_pick = workspace.picks[triggerID]
 
             for (ml_time, ml_conf) in preds:
                 seiscomp.logging.info("PICK   %s" % pick_id)
                 seiscomp.logging.info("RESULT %s  c= %.2f" %
                             (timestamp(ml_time), ml_conf))
 
-                dt_max = 10
-                dt = abs(ml_time - obspy.UTCDateTime(triggering_pick.time))
-                if abs(dt) > dt_max:
-                    seiscomp.logging.info("SKIPPED dt = %.2f" % dt)
-                    continue
-                if ml_conf < self.pickingConfig.minConfidence:
+                if phaseType[0] == 'P':
+                    dt_max = 10
+                    dt = abs(ml_time - obspy.UTCDateTime(triggering_pick.time))
+                    if abs(dt) > dt_max:
+                        seiscomp.logging.info("SKIPPED dt = %.2f" % dt)
+                        continue
+                
+                minConfidence = self.pickingConfig.minConfidence
+                
+                if ml_conf < minConfidence:
                     seiscomp.logging.info("SKIPPED conf = %.3f" % ml_conf)
                     continue
-                old_pick = workspace.picks[pick_id]
+                
+                old_pick = workspace.picks[triggerID]
                 new_pick = old_pick.copy()
-                new_pick.publicID = old_pick.publicID + "/repick"
+                new_pick.publicID = old_pick.publicID + "/repick_" + phaseType
                 new_pick.model = self.pickingConfig.modelName
                 new_pick.confidence = float("%.3f" % ml_conf)
                 new_pick.time = timestamp(ml_time)
+                new_pick.phaseHint = phaseType
+
 
                 workspace.mlpicks[pick_id] = new_pick
 
@@ -481,6 +491,31 @@ class App(seiscomp.client.Application):
 
         return True
 
+
+    def process_one_annotation (self, phaseType, annotation, annotDir, predictions, pick, peakHeight):
+        annot_f = annotDir / (dotted_nslc(pick) + "_" + phaseType + ".sac")
+        annotation.write(str(annot_f), format="SAC")
+
+        confidence = annotation.data.astype(np.double)
+        times = annotation.times()
+
+        pickID = str(pick.publicID) + "_" + phaseType
+
+        # The required min. distance between peaks is one second,
+        # i.e. the sampling rate controls the number of samples.
+        peaks, _ = scipy.signal.find_peaks(
+            confidence, height=peakHeight, distance=self.model.sampling_rate)
+        for peak in peaks:
+            picktime = annotation.stats.starttime + times[peak]
+            if pickID not in predictions:
+                predictions[pickID] = []
+            new_item = (picktime, confidence[peak])
+            predictions[pickID].append(new_item)
+            seiscomp.logging.debug(
+                "#### " + pickID + "  %.3f" % confidence[peak])
+        return predictions
+
+
     def fill_result(self, predictions, stream, collected_picks,
                     annotDir, eventID):
         """Fills `predictions` with annotations done by the model
@@ -494,12 +529,23 @@ class App(seiscomp.client.Application):
             annotations = self.model.annotate(stream)
 
             # Only use those predictions that were done for P wave onsets
-            annotations = list(filter(
+            annotationsP = list(filter(
                 lambda a: a.id.split('.')[-1].endswith('_P'), annotations))
+
+            
+
+            # Get S annotations if they exist. If there are no S annotations we will just get an empty list and skip the S phase picking later.
+            annotationsS = list(filter(
+                lambda a: a.id.split('.')[-1].endswith('_S'), annotations))
 
             # indexes list of successfully associated annotations
             assoc_ind = []
-            for i, annotation in enumerate(annotations):
+            
+            
+            for i, annotation in enumerate(annotationsP):
+                # We are working under the assumption that all pickers provide P picks and that S picks are optional
+                annotationP = annotationsP[i]
+                
                 try:
                     # Associate the annotation to a Pick
 
@@ -530,24 +576,14 @@ class App(seiscomp.client.Application):
                     continue
 
                 assoc_ind.append(i)
-                annot_f = annotDir / (dotted_nslc(pick) + ".sac")
-                annotation.write(str(annot_f), format="SAC")
 
-                confidence = annotation.data.astype(np.double)
-                times = annotation.times()
-
-                # The required min. distance between peaks is one second,
-                # i.e. the sampling rate controls the number of samples.
-                peaks, _ = scipy.signal.find_peaks(
-                    confidence, height=0.1, distance=self.model.sampling_rate)
-                for peak in peaks:
-                    picktime = annotation.stats.starttime + times[peak]
-                    if pick.publicID not in predictions:
-                        predictions[pick.publicID] = []
-                    new_item = (picktime, confidence[peak])
-                    predictions[pick.publicID].append(new_item)
-                    seiscomp.logging.debug(
-                        "#### " + pick.publicID + "  %.3f" % confidence[peak])
+                predictions = self.process_one_annotation("P", annotationP, annotDir, predictions, pick, self.pickingConfig.minConfidence)
+                
+                # If we have S annotations, we process them as well. This can be configured in the config file.
+                if self.pickingConfig.pickSphase == True:
+                    if len(annotationsS) > 0:
+                        annotationS = annotationsS[i]
+                        predictions = self.process_one_annotation("S", annotationS, annotDir, predictions, pick, self.pickingConfig.minConfidence)
 
                 collected_picks.remove(pick)
 

--- a/etc/defaults/scdlpicker.cfg
+++ b/etc/defaults/scdlpicker.cfg
@@ -49,8 +49,8 @@ scdlpicker.stationBlacklist = WA.ZON, JP.JEW, JP.JEM, JP.JNU
 scdlpicker.picking.dataset = geofon
 scdlpicker.picking.modelName = eqtransformer
 scdlpicker.picking.batchSize = 100
-scdlpicker.picking.minConfidence = 0.4
-
+scdlpicker.picking.minConfidence = 0.4 # For now, this is used for both P and S picks, but we might want to split this up in the future.
+scdlpicker.picking.pickSphase = True # Set to True to pick S phases, False to only pick P phases.
 
 ######## repicking
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -72,7 +72,10 @@ class PickingConfig:
         self.repickManualPicks = False
 
         self.minConfidence = 0.4
-
+        
+        self.pickSphase = True
+    
+        
         self.batchSize = 1
 
         # The SeisComP messaging group the created picks will be sent to
@@ -218,6 +221,11 @@ def getPickingConfig(app):
         pass
     try:
         config.minConfidence = app.commandline().optionDouble("min-confidence")
+    except RuntimeError:
+        pass
+
+    try:
+        config.pickSphase = app.configGetBool("scdlpicker.picking.pickSphase")
     except RuntimeError:
         pass
 

--- a/lib/dbutil.py
+++ b/lib/dbutil.py
@@ -284,7 +284,9 @@ def loadPicksForOrigin(query, origin, inventory, allowedAuthorIDs, maxDelta, max
         picks.append(pick)
 
         phase = seiscomp.datamodel.Phase()
-        phase.setCode("P")
+        phaseType = pick.phaseHint().code()
+        phase.setCode(phaseType)
+
         arr = seiscomp.datamodel.Arrival()
         arr.setPhase(phase)
         arr.setPickID(pickID)

--- a/lib/util.py
+++ b/lib/util.py
@@ -462,10 +462,11 @@ def readRepickerResults(path):
         # use the other picks e.g. as depth phases.
 
         for p in yaml.safe_load(yamlfile):
-            pickID = p["publicID"]
-            if seiscomp.datamodel.Pick.Find(pickID):
-                seiscomp.logging.debug("FIXME: "+pickID)
+            yamlPickID = p["publicID"]
+            if seiscomp.datamodel.Pick.Find(yamlPickID):
+                seiscomp.logging.debug("FIXME: "+yamlPickID)
             time = seiscomp.core.Time.FromString(p["time"], "%FT%T.%fZ")
+            
             tq = seiscomp.datamodel.TimeQuantity()
             tq.setValue(time)
             net = p["networkCode"]
@@ -474,6 +475,8 @@ def readRepickerResults(path):
             cha = p["channelCode"]
             if len(cha) == 2:
                 cha += "Z"
+            phaseType = p["phaseHint"]
+            
             wfid = seiscomp.datamodel.WaveformStreamID()
             wfid.setNetworkCode(net)
             wfid.setStationCode(sta)
@@ -481,19 +484,27 @@ def readRepickerResults(path):
             wfid.setChannelCode(cha)
 
             model = p["model"].lower()
-            if model in ["eqt", "eqtransformer"]:
-                mth = "EQT"
-            elif model in ["phn", "phasenet"]:
-                mth = "PHN"
-            else:
-                mth = "XYZ"
+            # if model in ["eqt", "eqtransformer"]:
+            #     mth = "EQT"
+            # elif model in ["phn", "phasenet"]:
+            #     mth = "PHN"
+            # else:
+            #     mth = "XYZ"
+            mth = model + '_' + phaseType
+            
+            
             decimals = 2
             nslcstr = net + "." + sta + "." + loc + "." + cha[:2]
             timestr = time.toString("%Y%m%d.%H%M%S.%f000000")[:16+decimals]
-            pickID = timestr + "-" + mth + "-" + nslcstr
+            pickID = timestr + "-" + nslcstr + "-" + mth
             pick = seiscomp.datamodel.Pick(pickID)
             pick.setTime(tq)
             pick.setWaveformID(wfid)
+
+            phase = seiscomp.datamodel.Phase()
+            phase.setCode(phaseType)
+            pick.setPhaseHint(phase)
+
 
             comments = []
 
@@ -521,9 +532,6 @@ def readRepickerResults(path):
         for pickID in picks:
             pick = picks[pickID]
             pick.setMethodID("DL")
-            phase = seiscomp.datamodel.Phase()
-            phase.setCode("P")
-            pick.setPhaseHint(phase)
             pick.setEvaluationMode(seiscomp.datamodel.AUTOMATIC)
 
     return picks, comms


### PR DESCRIPTION
Description
This PR adds support for optional S-phase picking in the repicking workflow.

Changes:
- Introduced a dedicated configuration switch to enable/disable S picking.
- Updated module configuration description/defaults to expose the new option.
- This enables users to include S arrivals when needed, while keeping the previous behavior available via configuration.

Also refines timestamp serialization in _scdlpicker-repicker.py_ to produce consistent UTC millisecond-formatted pick times (previous version was causing issues in SeisComP7)

